### PR TITLE
Change color() in ViewActions to defaultColor() so that it can be overidden if need be

### DIFF
--- a/packages/actions/src/ViewAction.php
+++ b/packages/actions/src/ViewAction.php
@@ -27,7 +27,7 @@ class ViewAction extends Action
         $this->modalSubmitAction(false);
         $this->modalCancelAction(fn (StaticAction $action) => $action->label(__('filament-actions::view.single.modal.actions.close.label')));
 
-        $this->color('gray');
+        $this->defaultColor('gray');
 
         $this->groupedIcon(FilamentIcon::resolve('actions::view-action.grouped') ?? 'heroicon-m-eye');
 

--- a/packages/tables/src/Actions/ViewAction.php
+++ b/packages/tables/src/Actions/ViewAction.php
@@ -28,7 +28,7 @@ class ViewAction extends Action
         $this->modalSubmitAction(false);
         $this->modalCancelAction(fn (StaticAction $action) => $action->label(__('filament-actions::view.single.modal.actions.close.label')));
 
-        $this->color('gray');
+        $this->defaultColor('gray');
 
         $this->icon(FilamentIcon::resolve('actions::view-action') ?? 'heroicon-m-eye');
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Changed color() in ViewActions to defaultColor() so that it can be overidden if need be using configureUsing().

I wanted to change the color of my ViewActions globally but even when using ViewAction::configureUsing() I noticed that the color was not changing from the default "gray". I noticed that in all ViewActions, the color is strictly set to "gray". So the only way to override this was to specify ->color() on every single ViewAction in my project.

So, to be able to configure to color of the ViewActions globally, I've updated $this->color('gray') to $this->defaultColor('gray'). This way, it should not harm anything as people who have used ViewAction::color(xxx) should not be affected.

## Visual changes

Before:
```
ViewAction::configureUsing( function(TableViewAction $action) {
     $action->color(Color::Lime);
});
```
![image](https://github.com/user-attachments/assets/dc25c409-2c96-4808-b727-9981453ecb3c)

After 
(with ConfigureUsing override):
```
ViewAction::configureUsing( function(TableViewAction $action) {
     $action->color(Color::Lime);
});
```
![image](https://github.com/user-attachments/assets/057db406-3f1f-4bf3-9471-565a86888d14)

(without ConfigureUsing override):
![image](https://github.com/user-attachments/assets/b8cfac2d-bdc5-4ab5-a5b6-5db0a77e3439)



## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
