### PR TITLE
Changed the use of color() to defaultColor() in all actions whereby color() was already defined

### DIFF
--- a/packages/actions/src/DeleteAction.php
+++ b/packages/actions/src/DeleteAction.php
@@ -27,7 +27,7 @@ class DeleteAction extends Action
 
         $this->successNotificationTitle(__('filament-actions::delete.single.notifications.deleted.title'));
 
-        $this->color('danger');
+        $this->defaultColor('danger');
 
         $this->groupedIcon(FilamentIcon::resolve('actions::delete-action.grouped') ?? 'heroicon-m-trash');
 

--- a/packages/actions/src/ForceDeleteAction.php
+++ b/packages/actions/src/ForceDeleteAction.php
@@ -25,7 +25,7 @@ class ForceDeleteAction extends Action
 
         $this->modalSubmitActionLabel(__('filament-actions::force-delete.single.modal.actions.delete.label'));
 
-        $this->color('danger');
+        $this->defaultColor('danger');
 
         $this->groupedIcon(FilamentIcon::resolve('actions::force-delete-action.grouped') ?? 'heroicon-m-trash');
 

--- a/packages/actions/src/RestoreAction.php
+++ b/packages/actions/src/RestoreAction.php
@@ -27,7 +27,7 @@ class RestoreAction extends Action
 
         $this->successNotificationTitle(__('filament-actions::restore.single.notifications.restored.title'));
 
-        $this->color('gray');
+        $this->defaultColor('gray');
 
         $this->groupedIcon(FilamentIcon::resolve('actions::restore-action.grouped') ?? 'heroicon-m-arrow-uturn-left');
 

--- a/packages/tables/src/Actions/AssociateAction.php
+++ b/packages/tables/src/Actions/AssociateAction.php
@@ -66,7 +66,7 @@ class AssociateAction extends Action
 
         $this->successNotificationTitle(__('filament-actions::associate.single.notifications.associated.title'));
 
-        $this->color('gray');
+        $this->defaultColor('gray');
 
         $this->form(fn (): array => [$this->getRecordSelect()]);
 

--- a/packages/tables/src/Actions/AttachAction.php
+++ b/packages/tables/src/Actions/AttachAction.php
@@ -66,7 +66,7 @@ class AttachAction extends Action
 
         $this->successNotificationTitle(__('filament-actions::attach.single.notifications.attached.title'));
 
-        $this->color('gray');
+        $this->defaultColor('gray');
 
         $this->form(fn (): array => [$this->getRecordSelect()]);
 

--- a/packages/tables/src/Actions/BulkActionGroup.php
+++ b/packages/tables/src/Actions/BulkActionGroup.php
@@ -14,7 +14,7 @@ class BulkActionGroup extends ActionGroup
 
         $this->icon(FilamentIcon::resolve('tables::actions.open-bulk-actions') ?? 'heroicon-m-ellipsis-vertical');
 
-        $this->color('gray');
+        $this->defaultColor('gray');
 
         $this->button();
 

--- a/packages/tables/src/Actions/DeleteAction.php
+++ b/packages/tables/src/Actions/DeleteAction.php
@@ -27,7 +27,7 @@ class DeleteAction extends Action
 
         $this->successNotificationTitle(__('filament-actions::delete.single.notifications.deleted.title'));
 
-        $this->color('danger');
+        $this->defaultColor('danger');
 
         $this->icon(FilamentIcon::resolve('actions::delete-action') ?? 'heroicon-m-trash');
 

--- a/packages/tables/src/Actions/DeleteBulkAction.php
+++ b/packages/tables/src/Actions/DeleteBulkAction.php
@@ -30,7 +30,7 @@ class DeleteBulkAction extends BulkAction
 
         $this->successNotificationTitle(__('filament-actions::delete.multiple.notifications.deleted.title'));
 
-        $this->color('danger');
+        $this->defaultColor('danger');
 
         $this->icon(FilamentIcon::resolve('actions::delete-action') ?? 'heroicon-m-trash');
 

--- a/packages/tables/src/Actions/DetachAction.php
+++ b/packages/tables/src/Actions/DetachAction.php
@@ -29,7 +29,7 @@ class DetachAction extends Action
 
         $this->successNotificationTitle(__('filament-actions::detach.single.notifications.detached.title'));
 
-        $this->color('danger');
+        $this->defaultColor('danger');
 
         $this->icon(FilamentIcon::resolve('actions::detach-action') ?? 'heroicon-m-x-mark');
 

--- a/packages/tables/src/Actions/DetachBulkAction.php
+++ b/packages/tables/src/Actions/DetachBulkAction.php
@@ -30,7 +30,7 @@ class DetachBulkAction extends BulkAction
 
         $this->successNotificationTitle(__('filament-actions::detach.multiple.notifications.detached.title'));
 
-        $this->color('danger');
+        $this->defaultColor('danger');
 
         $this->icon(FilamentIcon::resolve('actions::detach-action') ?? 'heroicon-m-x-mark');
 

--- a/packages/tables/src/Actions/DissociateAction.php
+++ b/packages/tables/src/Actions/DissociateAction.php
@@ -29,7 +29,7 @@ class DissociateAction extends Action
 
         $this->successNotificationTitle(__('filament-actions::dissociate.single.notifications.dissociated.title'));
 
-        $this->color('danger');
+        $this->defaultColor('danger');
 
         $this->icon(FilamentIcon::resolve('actions::dissociate-action') ?? 'heroicon-m-x-mark');
 

--- a/packages/tables/src/Actions/DissociateBulkAction.php
+++ b/packages/tables/src/Actions/DissociateBulkAction.php
@@ -30,7 +30,7 @@ class DissociateBulkAction extends BulkAction
 
         $this->successNotificationTitle(__('filament-actions::dissociate.multiple.notifications.dissociated.title'));
 
-        $this->color('danger');
+        $this->defaultColor('danger');
 
         $this->icon(FilamentIcon::resolve('actions::dissociate-action') ?? 'heroicon-m-x-mark');
 

--- a/packages/tables/src/Actions/ForceDeleteAction.php
+++ b/packages/tables/src/Actions/ForceDeleteAction.php
@@ -27,7 +27,7 @@ class ForceDeleteAction extends Action
 
         $this->successNotificationTitle(__('filament-actions::force-delete.single.notifications.deleted.title'));
 
-        $this->color('danger');
+        $this->defaultColor('danger');
 
         $this->icon(FilamentIcon::resolve('actions::force-delete-action') ?? 'heroicon-m-trash');
 

--- a/packages/tables/src/Actions/ForceDeleteBulkAction.php
+++ b/packages/tables/src/Actions/ForceDeleteBulkAction.php
@@ -30,7 +30,7 @@ class ForceDeleteBulkAction extends BulkAction
 
         $this->successNotificationTitle(__('filament-actions::force-delete.multiple.notifications.deleted.title'));
 
-        $this->color('danger');
+        $this->defaultColor('danger');
 
         $this->icon(FilamentIcon::resolve('actions::force-delete-action') ?? 'heroicon-m-trash');
 

--- a/packages/tables/src/Actions/RestoreAction.php
+++ b/packages/tables/src/Actions/RestoreAction.php
@@ -27,7 +27,7 @@ class RestoreAction extends Action
 
         $this->successNotificationTitle(__('filament-actions::restore.single.notifications.restored.title'));
 
-        $this->color('gray');
+        $this->defaultColor('gray');
 
         $this->icon(FilamentIcon::resolve('actions::restore-action') ?? 'heroicon-m-arrow-uturn-left');
 

--- a/packages/tables/src/Actions/RestoreBulkAction.php
+++ b/packages/tables/src/Actions/RestoreBulkAction.php
@@ -30,7 +30,7 @@ class RestoreBulkAction extends BulkAction
 
         $this->successNotificationTitle(__('filament-actions::restore.multiple.notifications.restored.title'));
 
-        $this->color('gray');
+        $this->defaultColor('gray');
 
         $this->icon(FilamentIcon::resolve('actions::restore-action') ?? 'heroicon-m-arrow-uturn-left');
 


### PR DESCRIPTION
## Description

Changed the use of color() to defaultColor() in all actions whereby color() was already defined as requested on https://github.com/filamentphp/filament/pull/16100#pullrequestreview-2796161925

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
