### PR TITLE
change color() to default() color

### DIFF
--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -255,7 +255,7 @@ trait CanExportRecords
             }
         });
 
-        $this->color('gray');
+        $this->defaultColor('gray');
 
         $this->modalWidth('xl');
 

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -383,7 +383,7 @@ trait CanImportRecords
                 }),
         ]);
 
-        $this->color('gray');
+        $this->defaultColor('gray');
 
         $this->modalWidth('xl');
 

--- a/packages/forms/src/Components/TextInput/Actions/HidePasswordAction.php
+++ b/packages/forms/src/Components/TextInput/Actions/HidePasswordAction.php
@@ -20,7 +20,7 @@ class HidePasswordAction extends Action
 
         $this->icon(FilamentIcon::resolve('forms::components.text-input.actions.hide-password') ?? 'heroicon-m-eye-slash');
 
-        $this->color('gray');
+        $this->defaultColor('gray');
 
         $this->extraAttributes([
             'x-cloak' => true,

--- a/packages/forms/src/Components/TextInput/Actions/ShowPasswordAction.php
+++ b/packages/forms/src/Components/TextInput/Actions/ShowPasswordAction.php
@@ -20,7 +20,7 @@ class ShowPasswordAction extends Action
 
         $this->icon(FilamentIcon::resolve('forms::components.text-input.actions.show-password') ?? 'heroicon-m-eye');
 
-        $this->color('gray');
+        $this->defaultColor('gray');
 
         $this->extraAttributes([
             'x-show' => '! isPasswordRevealed',


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
Changed the use of color() to defaultColor() in all actions whereby color() was already defined as requested on https://github.com/filamentphp/filament/pull/16100#pullrequestreview-2796161925

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
