### PR TITLE
bugfix: Tenant menu icon blade component needs to use alias instead of icon-alias

### DIFF
--- a/packages/panels/resources/views/components/tenant-menu.blade.php
+++ b/packages/panels/resources/views/components/tenant-menu.blade.php
@@ -79,7 +79,7 @@
 
             <x-filament::icon
                 icon="heroicon-m-chevron-down"
-                icon-alias="panels::tenant-menu.toggle-button"
+                alias="panels::tenant-menu.toggle-button"
                 :x-show="filament()->isSidebarCollapsibleOnDesktop() ? '$store.sidebar.isOpen' : null"
                 class="ms-auto h-5 w-5 shrink-0 text-gray-400 transition duration-75 group-hover:text-gray-500 group-focus-visible:text-gray-500 dark:text-gray-500 dark:group-hover:text-gray-400 dark:group-focus-visible:text-gray-400"
             />


### PR DESCRIPTION

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
I was attempting to change the icon for the tenant drop down menu however using the following code was not updating the icon:
```
\Filament\Support\Facades\FilamentIcon::register([
  // ...
  'panels::tenant-menu.toggle-button' => 'my-custom-icon-name',
  // ...
]);
```
After doing some digging, I found that `<x-filament::icon>` in `tenant-menu.blade.php` that renders the icon was using `icon-alias` but the property name for this component is `alias`.

## Visual changes
### Before:
![image](https://github.com/user-attachments/assets/1a3c8566-e734-44cd-9cd8-63a9f3e864c0)

### After (example purposes only to show that the icon is now changed as expected):
![image](https://github.com/user-attachments/assets/1bb72126-8ae6-4045-8029-78ab1591e391)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
